### PR TITLE
Trim newline from instrument's response.

### DIFF
--- a/Oscilloscope/Oscilloscope.cs
+++ b/Oscilloscope/Oscilloscope.cs
@@ -116,7 +116,8 @@ public partial class Oscilloscope
 
     public string ReadString()
     {
-        return _mbSession.RawIO.ReadString();
+        // Read the response; omit end-of-line characters.
+        return _mbSession.RawIO.ReadString().TrimEnd( '\r', '\n');
     }
 
     public byte[] Read()


### PR DESCRIPTION
I'm testing this library for the Rigol MSO5354, which gives newline characters at the end of all its SCPI response strings.  This breaks the library unless they are trimmed after being read.